### PR TITLE
Add two apps to list of Diet trackers

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -90,6 +90,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Calorie Counter](https://www.caloriecount.com/) - Nutritional database and calorie counting app (iOS & Android).
 - [Cronometer](https://cronometer.com/) - Food, activity, and biometric tracker (iOS & Android).
 - [Zero](https://itunes.apple.com/us/app/zero-fasting-tracker/id1168348542?mt=8) - A simple fasting tracker used for intermittent, circadian rhythm, and custom fasting (iOS). 
+- [Vora](https://play.google.com/store/apps/details?id=com.fastapp&hl=en_US) Fasting tracker (Android).
 - [Bitesnap](https://www.getbitesnap.com/) - Image based food logging app powered by computer vision (iOS & Android).
 
 ### Goals

--- a/README.MD
+++ b/README.MD
@@ -88,6 +88,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [MyFitnessPal](http://www.myfitnesspal.com/) - Food tracking and diet plan app (iOS & Android).
 - [Fat Secret](https://www.fatsecret.com/) - Calorie counter and diet tracker for weight loss (iOS & Android).
 - [Calorie Counter](https://www.caloriecount.com/) - Nutritional database and calorie counting app (iOS & Android).
+- [Cronometer](https://cronometer.com/) - Food, activity, and biometric tracker (iOS & Android).
 - [Zero](https://itunes.apple.com/us/app/zero-fasting-tracker/id1168348542?mt=8) - A simple fasting tracker used for intermittent, circadian rhythm, and custom fasting (iOS). 
 - [Bitesnap](https://www.getbitesnap.com/) - Image based food logging app powered by computer vision (iOS & Android).
 

--- a/README.MD
+++ b/README.MD
@@ -89,7 +89,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Fat Secret](https://www.fatsecret.com/) - Calorie counter and diet tracker for weight loss (iOS & Android).
 - [Calorie Counter](https://www.caloriecount.com/) - Nutritional database and calorie counting app (iOS & Android).
 - [Cronometer](https://cronometer.com/) - Food, activity, and biometric tracker (iOS & Android).
-- [Zero](https://itunes.apple.com/us/app/zero-fasting-tracker/id1168348542?mt=8) - A simple fasting tracker used for intermittent, circadian rhythm, and custom fasting (iOS). 
+- [Zero](https://www.zerofasting.com/) - A simple fasting tracker used for intermittent, circadian rhythm, and custom fasting (iOS & Android). 
 - [Vora](https://getvora.com/) - Fasting tracker (iOS & Android).
 - [Bitesnap](https://www.getbitesnap.com/) - Image based food logging app powered by computer vision (iOS & Android).
 

--- a/README.MD
+++ b/README.MD
@@ -90,7 +90,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Calorie Counter](https://www.caloriecount.com/) - Nutritional database and calorie counting app (iOS & Android).
 - [Cronometer](https://cronometer.com/) - Food, activity, and biometric tracker (iOS & Android).
 - [Zero](https://itunes.apple.com/us/app/zero-fasting-tracker/id1168348542?mt=8) - A simple fasting tracker used for intermittent, circadian rhythm, and custom fasting (iOS). 
-- [Vora](https://play.google.com/store/apps/details?id=com.fastapp&hl=en_US) Fasting tracker (Android).
+- [Vora](https://getvora.com/) - Fasting tracker (iOS & Android).
 - [Bitesnap](https://www.getbitesnap.com/) - Image based food logging app powered by computer vision (iOS & Android).
 
 ### Goals


### PR DESCRIPTION
I've added two apps that I've found extremely helpful to the list of Diet apps.

First is Cronometer, which is the best food tracker I've used. Beats the pro version of MyFitnessPal with ease (and at less cost). It shows way, way more data on micronutrients consumed than MFP. And it links with other tools like Fitbit to automatically include weight, activity, sleep, etc.

Second is Vora, which I use for fasting. I hear great things about Zero and would love to try it, but it's not available for Android. Vora has been a very useful alternative for me.

I hope these are useful contributions. Thank you for compiling such a great list!