### PR TITLE
Move shutdown, EveryMove acquired by Higi

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -50,7 +50,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Runkeeper](http://runkeeper.com/) - Outdoor fitness activity tracker (iOS & Android).
 - [Endomondo](https://www.endomondo.com/) - Sport and health statistics tracker (iOS & Android).
 - [Runtastic](https://www.runtastic.com/) - Running, cycling, and fitness GPS tracker (iOS & Android).
-- [EveryMove Fit](http://everymovefit.com/) - Social fitness and goal tracking platform (iOS & Android).
+- (Acquired by Higi) [EveryMove Fit](http://everymovefit.com/) - Social fitness and goal tracking platform (iOS & Android).
 - [Strava](https://www.strava.com/) - Athletic activity tracking and social network.
 - [Gym Hero](https://gymhero.me/) - Track workouts, strength training and other fitness exercise (iOS, Web)
 
@@ -58,7 +58,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [RoadGoat](https://www.roadgoat.com/) - Travel tracking, automated integrations with many platforms listed here (Web).
 - [Swarm](https://www.swarmapp.com/) - Point of interest auto-checkins via GPS (iOS & Android).
 - [Arc](https://itunes.apple.com/us/app/arc-app-location-activity/id1063151918) - Track your movements and places visited via GPS (iOS).
-- [Moves](https://moves-app.com/) - Activity diary for your life, now shut down (iOS & Android).  
+- (Service Shutdown) [Moves](https://moves-app.com/) - Activity diary for your life, now shut down (iOS & Android).
 
 ### Aggregators & Dashboards
 - [Memento Labs](https://mementolabs.io) - Personalized health and wellness action plans using wearables & A/B testing. 


### PR DESCRIPTION
Hi, we need a way to mark a service/app shutdown in the future cause lots of might dead. I just mark Move first cause it's already shutdown for a long time
- Marked Move as service shutdown
- add EveryMove acquired by Higi and no longer exist