### PR TITLE
A place for stop service/hardware in ARCHIVED.md

### DIFF
--- a/ARCHIVED.md
+++ b/ARCHIVED.md
@@ -1,0 +1,17 @@
+# Archived
+
+This is the place that a service/hardware etc. is shutdown, stopped or been acquired.
+
+## Contents
+
+- [Applications and Platforms](#applications-and-platforms)
+
+
+
+##applications-and-platforms
+
+### Fitness
+- [EveryMove Fit](http://everymovefit.com/) - 2017-03-15 acquired by Higi.
+
+### Places & Travel
+- [Moves](https://www.moves-app.com/) - 2018-07-31, Moves shutdown by Facebook.

--- a/ARCHIVED.md
+++ b/ARCHIVED.md
@@ -11,7 +11,7 @@ This is the place that a service/hardware etc. is shutdown, stopped or been acqu
 ##applications-and-platforms
 
 ### Fitness
-- [EveryMove Fit](http://everymovefit.com/) - 2017-03-15 acquired by Higi.
+- [EveryMove Fit](http://everymovefit.com/) - 2017-03-15 acquired by Higi, service stop.
 
 ### Places & Travel
 - [Moves](https://www.moves-app.com/) - 2018-07-31, Moves shutdown by Facebook.

--- a/README.MD
+++ b/README.MD
@@ -10,6 +10,8 @@ The [Quantified Self](https://en.wikipedia.org/wiki/Quantified_Self) is a moveme
 
 Contributions welcome. Add links through pull requests or create an issue to start a discussion.
 
+It's always been sad to see a service shutdown, or hardware stop renew, here is the list we gather that have this tough decision [Archived](ARCHIVED.md)
+
 ## Contents
 
 - [Websites and Resources](#websites-and-resources)

--- a/README.MD
+++ b/README.MD
@@ -57,7 +57,6 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Runkeeper](http://runkeeper.com/) - Outdoor fitness activity tracker (iOS & Android).
 - [Endomondo](https://www.endomondo.com/) - Sport and health statistics tracker (iOS & Android).
 - [Runtastic](https://www.runtastic.com/) - Running, cycling, and fitness GPS tracker (iOS & Android).
-- [EveryMove Fit](http://everymovefit.com/) - Social fitness and goal tracking platform (iOS & Android).
 - [Strava](https://www.strava.com/) - Athletic activity tracking and social network.
 - [Gym Hero](https://gymhero.me/) - Track workouts, strength training and other fitness exercise (iOS, Web)
 


### PR DESCRIPTION
Got new ARCHIVED.md created and put two known services, Moves & EveryMove Fit.
Remove EverMove Fit from README.md
Add the link to go to ARCHIVED.md