### PR TITLE
Change workflow to Apple Shortcuts

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -86,7 +86,7 @@ It's always been sad to see a service shutdown, or hardware stop renew, here is 
 
 ### Automation
 - [Tasker](https://play.google.com/store/apps/details?id=net.dinglisch.android.taskerm&hl=en) - Automation and event triggering app (Android).
-- [Workflow](http://workflow.is/) - Powerful automation app (iOS).
+- [Apple Shortcuts](https://support.apple.com/guide/shortcuts/welcome/ios) - Powerful automation app (iOS).
 - [If This Then That (IFTTT)](https://ifttt.com/) - Awesome conditional automation platform.
 - [Zapier](https://zapier.com/) - Automate tasks between apps.
 


### PR DESCRIPTION
"Workflow.is" was bought by Apple Inc. and turned into first party app which is core part of iOS now. The naming was changed a little with this change. While the old website still works, when you go to download it redirects to you the the new "Shortcuts" app as the old "Workflow" is not available anymore.

See here: 

* https://arstechnica.com/apple/2017/03/apple-snaps-up-workflow-an-ios-automation-app-for-power-users/
* https://9to5mac.com/2018/09/17/shortcuts-ios-12-now-available/
* https://www.apple.com/newsroom/2018/10/top-apps-make-everyday-tasks-even-easier-with-siri-shortcuts/