### PR TITLE
Add Athlytics to Open Source Projects

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -226,6 +226,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Chronicle](https://github.com/chronicle-app/chronicle-etl) - A CLI toolkit for extracting and working with your digital history.
 - [QS-Schema](https://github.com/QS-Schema/qs-schema) - Open schemes for QS applications.
 - [Datasette](https://github.com/simonw/datasette) - An open source multi-tool for exploring and publishing data.
+- [Athlytics](https://github.com/HzaCode/Athlytics) - Academic R toolkit for endurance analytics with offline processing of Strava data exports for training load and physiological metrics.
 
 ## License
 


### PR DESCRIPTION
This adds Athlytics to the Open Source Projects section.

**Why it's awesome:**
- Academic R toolkit specifically designed for endurance training analytics
- Works 100% offline with local Strava data exports (privacy-focused)
- Implements evidence-based sports science metrics (ACWR, Efficiency Factor, Pa:Hr Decoupling)
- Published on CRAN with comprehensive documentation
- Built for cohort analysis and multi-athlete comparisons

**Links:**
- GitHub: https://github.com/HzaCode/Athlytics
- Documentation: https://hezhiang.com/Athlytics/
- CRAN: https://cran.r-project.org/package=Athlytics