### PR TITLE
Add OpenHabitTracker to Habits

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -124,6 +124,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Emoji Log](https://emojilog.rosano.ca) - Track habits without streaks using emoji.
 - [Conjure](https://conjure.so) - Habits, goals and time tracker with rules engine, data layer, API, dashboards and more. (Web, Desktop, iOS, Android).
 - [MissionMate](https://www.missionmate.team/) - Virtual Habit Coach for in your groupchat (telegram). Log activities with photos or text, earn points, and compete with friends to build consistent habits together.
+- [OpenHabitTracker](https://openhabittracker.net) - Free, open source habit tracker with notes and tasks, available on Web, Windows, Linux, Android, iOS and macOS.
 
 ### Health
 - [AlcDroid](http://alcdroid.flx-apps.com/) - Alcohol consumption tracking and BAC calculation app that offers various statistics regarding your drinking behavior (Android).


### PR DESCRIPTION
OpenHabitTracker is a free, open source habit tracker with notes and tasks, available on Web, Windows, Linux, Android, iOS and macOS. https://openhabittracker.net