### PR TITLE
Add Pilgrim - privacy-first walking tracker (iOS)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -61,6 +61,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Strava](https://www.strava.com/) - Athletic activity tracking and social network.
 - [Gym Hero](https://gymhero.me/) - Track workouts, strength training and other fitness exercise (iOS, Web)
 - [OpenTracks](https://opentracksapp.com/) - Privacy-respecting offline-capable fitness activity tracker (Android).
+- [Pilgrim](https://github.com/walktalkmeditate/pilgrim-ios) - Privacy-first walking tracker with GPS route, altitude, steps, on-device voice journaling via WhisperKit, and meditation timing. All data stays on-device, no accounts or analytics. Open source (iOS).
 
 ### Places & Travel
 - [RoadGoat](https://www.roadgoat.com/) - Travel tracking, automated integrations with many platforms listed here (Web).


### PR DESCRIPTION
## Summary

Adds [Pilgrim](https://github.com/walktalkmeditate/pilgrim-ios) to the **Fitness** section under Applications and Platforms.

Pilgrim is a privacy-first walking companion for iOS that tracks:
- GPS route, distance, altitude, and steps
- Voice recordings with on-device transcription (WhisperKit)
- Meditation sessions with duration timing
- Weather context and moon phases

All data stays entirely on-device — no accounts, no analytics, no cloud. Free and open source (GPLv3).

- **GitHub**: https://github.com/walktalkmeditate/pilgrim-ios
- **App Store**: https://apps.apple.com/app/pilgrim-mindful-walking/id6760921056

## Checklist

- [x] Entry follows existing format: `[Name](URL) - Description (Platform).`
- [x] Added to appropriate section (Fitness)
- [x] Description highlights quantified-self relevance (walk metrics, voice journaling, meditation tracking)
- [x] Link points to open source repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)