### PR TITLE
Add lifeos-cli to Open Source Projects

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -226,6 +226,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Chronicle](https://github.com/chronicle-app/chronicle-etl) - A CLI toolkit for extracting and working with your digital history.
 - [QS-Schema](https://github.com/QS-Schema/qs-schema) - Open schemes for QS applications.
 - [Datasette](https://github.com/simonw/datasette) - An open source multi-tool for exploring and publishing data.
+- [lifeos-cli](https://github.com/liujuanjuan1984/lifeos-cli) - Terminal-native LifeOS for personal workflows, habits, and timelogs.
 
 ## License
 


### PR DESCRIPTION
## Summary
Add [lifeos-cli](https://github.com/liujuanjuan1984/lifeos-cli), a terminal-native LifeOS for managing personal workflows, intentions, habits, and timelogs with agent-friendly interface.