### PR TITLE
Add shenas — local-first personal analytics with on-device DuckDB

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -226,6 +226,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Chronicle](https://github.com/chronicle-app/chronicle-etl) - A CLI toolkit for extracting and working with your digital history.
 - [QS-Schema](https://github.com/QS-Schema/qs-schema) - Open schemes for QS applications.
 - [Datasette](https://github.com/simonw/datasette) - An open source multi-tool for exploring and publishing data.
+- [shenas](https://github.com/shenas-org/shenas) - Local-first personal analytics platform. Ingests data from health, finance, and activity services into a per-user DuckDB; raw data stays on your device and models train via federated learning.
 
 ## License
 


### PR DESCRIPTION
## What this adds

[shenas](https://github.com/shenas-org/shenas) is an open-source personal analytics platform that takes a different architectural approach from most aggregators already in this list.

**Why it belongs here:**

- Ingests from health, finance, and activity services (Garmin, Strava, Withings, Google Calendar, Spotify, Lunch Money, and more via a plugin system)
- Raw data lands in a per-user DuckDB on the user's own device — nothing leaves the machine
- Canonical metrics schema in a separate `metrics.*` layer, transformed from raw source tables
- Insights and dashboards run locally via pluggable Lit web components
- Federated learning (Flower + PyTorch) for population-level model training: only gradients travel, not raw data

**Where it fits:**

Added to **Open Source Projects**, after Datasette. It sits in the same space as HumanProgrammingInterface and Dogsheep — a self-hosted aggregator for your own data — but with a stronger privacy guarantee (local-only raw storage) and a built-in federated learning layer.

**Contribution checklist:**

- [x] Not a duplicate (checked existing list)
- [x] Format: `[resource](link) - Description.`
- [x] Description starts with capital, ends with period
- [x] Does not mention 'Quantified Self' in the description
- [x] Added to bottom of relevant category
- [x] Links to GitHub repo
