### PR TITLE
Add HabitIt to Habit Tracking section

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -124,6 +124,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Emoji Log](https://emojilog.rosano.ca) - Track habits without streaks using emoji.
 - [Conjure](https://conjure.so) - Habits, goals and time tracker with rules engine, data layer, API, dashboards and more. (Web, Desktop, iOS, Android).
 - [MissionMate](https://www.missionmate.team/) - Virtual Habit Coach for in your groupchat (telegram). Log activities with photos or text, earn points, and compete with friends to build consistent habits together.
+- [HabitIt](https://habitit.app) - Habit tracker with auto-tapering schedules. Habit chains, automatic pattern detection, money-saved counter, AI insights, Health sync (iOS, Android, Apple Watch, Wear OS).
 
 ### Health
 - [AlcDroid](http://alcdroid.flx-apps.com/) - Alcohol consumption tracking and BAC calculation app that offers various statistics regarding your drinking behavior (Android).


### PR DESCRIPTION
Added HabitIt to the Habits section.

HabitIt is a habit tracker with auto-tapering daily schedules for starting, quitting, or gradually reducing habits. It does structured daily logging, bidirectional Apple Health and Health Connect sync, and pattern detection over the user's behavior data, which fits the quantified-self theme of the list.

The wedge feature compared to other entries in this section (Habitica, Streaks, Productive, etc.) is the auto-tapering engine: the user sets a start value, target, and timeline, and the app generates the daily plan and recalibrates forward when the user misses a day, rather than breaking the streak.

iOS, Android, Apple Watch, Wear OS. Freemium with a Lifetime Pro IAP.

Happy to adjust the entry's length or wording if you'd prefer a different format.