### PR TITLE
Add Smart Runner to Fitness

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -61,6 +61,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Strava](https://www.strava.com/) - Athletic activity tracking and social network.
 - [Gym Hero](https://gymhero.me/) - Track workouts, strength training and other fitness exercise (iOS, Web)
 - [OpenTracks](https://opentracksapp.com/) - Privacy-respecting offline-capable fitness activity tracker (Android).
+- [Smart Runner](https://runnerapp.pro/) - Privacy-respecting on-device running and marathon training coach with adaptive plans (iOS & Apple Watch).
 
 ### Places & Travel
 - [RoadGoat](https://www.roadgoat.com/) - Travel tracking, automated integrations with many platforms listed here (Web).


### PR DESCRIPTION
Adds Smart Runner to the Fitness list. It is a privacy-respecting, on-device running and marathon training app for iPhone and Apple Watch: training data stays on the device (no account, no server), which fits alongside OpenTracks in this section.

Link: https://runnerapp.pro/

Full disclosure: I am the maker. Happy to adjust the wording or category to match the list's conventions.