### PR TITLE
Add Garmin AI Notifier

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -226,6 +226,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Chronicle](https://github.com/chronicle-app/chronicle-etl) - A CLI toolkit for extracting and working with your digital history.
 - [QS-Schema](https://github.com/QS-Schema/qs-schema) - Open schemes for QS applications.
 - [Datasette](https://github.com/simonw/datasette) - An open source multi-tool for exploring and publishing data.
+- [Garmin AI Notifier](https://github.com/deep0410/garmin-ai-notifier) - Free daily pipeline: pull Garmin Connect into SQLite, compute full-history wellness stats, generate a Gemini-written brief, and push to your phone (ntfy/Telegram/email). Runs on GitHub Actions.
 
 ## License
 


### PR DESCRIPTION
Adds [garmin-ai-notifier](https://github.com/deep0410/garmin-ai-notifier) under **Open Source Projects**.

Free daily pipeline for quantified-self folks with Garmin watches: pulls Garmin Connect into SQLite, computes full-history wellness statistics (percentiles, trends, streaks), generates a short Gemini brief, and pushes to phone via ntfy/Telegram/email. Runs on GitHub Actions ($0).

No GPS/activity routes stored — scalar daily health metrics only.

Made with [Cursor](https://cursor.com)