### PR TITLE
Add MirrorNotes — private AI journaling with on-device mood tracking (iOS)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -149,6 +149,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [MoodJam](http://moodjam.com/) - Track your moods with colors. (Web only).
 - [iMoodJournal](https://www.imoodjournal.com/) - Mood Tracking on a 10-point scale from Really great to Couldn't be worse. Exportable data. (Android, iOS, Apple Watch).
 - [Perspective](https://itunes.apple.com/us/app/perspective-daily-journal/id1186753097?mt=8) - Journaling to captures Thoughts, Moods, and Interests with the goal of helping you reflect and find perspective. (iOS).
+- [MirrorNotes](https://mirrornotes.org) - Private AI journaling with on-device mood tracking, daily reflection prompts, and "Ask your journal" queries. All AI (Gemma 3) runs locally — no data ever leaves your device. Free to write forever. (iOS).
 - [Moods by Mokriya](https://itunes.apple.com/us/app/moods-tracking-for-better-mental-health/id1023271188?mt=8) - Quick track your mood as good, okay or bad. Specify feelings using a word cloud. No data export option. (iOS, Apple Watch).
 
 ### Sleep


### PR DESCRIPTION
## What this adds

[MirrorNotes](https://mirrornotes.org) in the **Mood** section — a journaling app for iPhone where all AI (mood tracking, daily reflection prompts, Ask-your-journal) runs on-device via Gemma 3 1B. Nothing leaves the device.

## Why it fits

- Mood tracking: detects emotional tone across entries, shows patterns, and triggers Mood Alerts after 3 consecutive negative entries
- Journaling: daily prompts, weekly digest, monthly report — all quantified self data points
- iOS native, actively maintained, free to write forever

## Format matches existing entries

Same format as iMoodJournal, Perspective, Moods by Mokriya entries already in this section.

App Store: https://apps.apple.com/app/id6769007201