### PR TITLE
Add LogZero to Aggregators & Dashboards

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -81,6 +81,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [QS Access](https://apps.apple.com/us/app/qs-access/id920297614) - Export Apple Health data into CSV table format (iOS).
 - [KeepTrack](https://play.google.com/store/apps/details?id=com.zagalaga.keeptrack&hl=en) - Multi-purpose tracker (Android).
 - [BiomarkerDash](https://github.com/NoTranslationLayer/biomarkerdash) - Simple dashboard to visualize trends in bloodwork biomarkers.
+- [LogZero](https://logzero.app) - All-in-one private tracker (mood, food, weight, meds, exercise) with a local correlation engine that surfaces what actually moves your mood and weight; fully on-device, no account (iOS).
 
 ### Automation
 - [Tasker](https://play.google.com/store/apps/details?id=net.dinglisch.android.taskerm&hl=en) - Automation and event triggering app (Android).


### PR DESCRIPTION
Adds **LogZero** to the **Applications and Platforms → Aggregators & Dashboards** category (appended to the bottom, per the contributing guidelines).

```
- [LogZero](https://logzero.app) - All-in-one private tracker (mood, food, weight, meds, exercise) with a local correlation engine that surfaces what actually moves your mood and weight; fully on-device, no account (iOS).
```

**Why it's awesome:** LogZero is an all-in-one self-tracking app (mood, medication, food with calories/macros, exercise, meditation, weight, to-dos) with a built-in **local statistical correlation engine** that surfaces what actually moves your mood and weight, plus a dashboard with streaks and weekly insights. Unlike most aggregators here, everything runs **100% on-device** — no account, no ads, no analytics/telemetry, and zero network requests for your data (AES-256 at rest; App Store privacy label "Data Not Collected"). Optional user-controlled encrypted export/backup (CSV/JSON/encrypted).

- Website: https://logzero.app
- App Store: https://apps.apple.com/app/id6773557137

**Checklist**
- [x] Searched previous suggestions — not a duplicate.
- [x] Format `[resource](link) - Description.` with link and platform marker, matching neighboring entries.
- [x] Added to the bottom of the relevant category.
- [x] Starts with a capital, ends with a period; does not mention "Quantified Self".
- [x] No trailing whitespace.
- [x] Individual pull request for this single suggestion.
