### PR TITLE
Add CPAP Clarity to Sleep

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -155,6 +155,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Sleep as Android](http://sleep.urbandroid.org/) - Full featured sleep tracker with wearable integration (Android).
 - [Sleep Cycle](https://www.sleepcycle.com/) - Intelligent alarm clock and sleep tracker (iOS & Android).
 - [Pillow](https://neybox.com/pillow/) - Track your sleep from your Apple Watch or iPhone (iOS). 
+- [CPAP Clarity](https://cpapclarity.com) - Analyzes CPAP and sleep data in your browser and explains it in plain language, with no upload and no account (Web).
 
 ### Tally
 


### PR DESCRIPTION
Adds CPAP Clarity to the **Sleep** section.

CPAP Clarity is a free, browser-based tool that reads CPAP, pulse-oximeter, and wearable data entirely on-device (nothing is uploaded, no account) and explains it in plain language. Relevant to QS folks tracking sleep-therapy data alongside their wearables.

Follows CONTRIBUTING: added to the bottom of the category, in `[resource](link) - Description.` format, sentence case ending with a period.

Disclosure: I'm the creator.
