### PR TITLE
Add DailyVox to Mood

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -150,6 +150,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [iMoodJournal](https://www.imoodjournal.com/) - Mood Tracking on a 10-point scale from Really great to Couldn't be worse. Exportable data. (Android, iOS, Apple Watch).
 - [Perspective](https://itunes.apple.com/us/app/perspective-daily-journal/id1186753097?mt=8) - Journaling to captures Thoughts, Moods, and Interests with the goal of helping you reflect and find perspective. (iOS).
 - [Moods by Mokriya](https://itunes.apple.com/us/app/moods-tracking-for-better-mental-health/id1023271188?mt=8) - Quick track your mood as good, okay or bad. Specify feelings using a word cloud. No data export option. (iOS, Apple Watch).
+- [DailyVox](https://getdailyvox.com) - Voice journal that tracks mood and surfaces patterns on-device, building a private "Digital Twin" from your spoken entries. No account or cloud; free and open source (iOS).
 
 ### Sleep
 - [Sleep as Android](http://sleep.urbandroid.org/) - Full featured sleep tracker with wearable integration (Android).


### PR DESCRIPTION
DailyVox is a free, open-source (MIT) voice journal for iOS that doubles as a quantified-self tool for your inner life: it tracks **mood** and surfaces recurring patterns over time, building a private on-device "Digital Twin" from your spoken entries. Everything runs on-device — no account, no cloud, no data collection. Added under **Mood**.

Site: https://getdailyvox.com · Source: https://github.com/intrepidkarthi/dailyvox