### PR TITLE
Add Folicle to Health

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -127,6 +127,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 
 ### Health
 - [AlcDroid](http://alcdroid.flx-apps.com/) - Alcohol consumption tracking and BAC calculation app that offers various statistics regarding your drinking behavior (Android).
+- [Folicle](https://folicle.app/) - Hair-growth tracker with aligned scalp photos, a numeric Hair Score over time, and dermatologist-ready exports; non-diagnostic (iOS, Android).
 
 ### Heart
 - [Instant Heart Rate](http://www.azumio.com/s/instantheartrate/index.html) - Fast and accurate mobile heart rate monitor (iOS, Android, Windows).


### PR DESCRIPTION
Adds Folicle under **Health**.

Folicle is a self-tracking tool for hair: you take aligned scalp photos over time, it turns them into a numeric Hair Score you can trend, and exports a dermatologist-ready report. It's non-diagnostic and consumer-facing (iOS, Android).

The Health section currently has no hair-tracking entry, so this fills a genuine gap in the list rather than duplicating an existing one. Entry follows the existing one-line `[Name](url) - description (platforms).` format.