### PR TITLE
Add Ori to Mind & Cognition section

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -143,7 +143,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Podcast Tracker](http://www.podcasttracker.com/) -  Lets you log, aggregate and export your podcast listening history (Web).
 
 ### Mind & Cognition
-- [Ori](https://talk-to-me.ideaflow.page/) - Cognitive-health journal that fuses your writing with biometric and wellbeing (WHO-5) data and writes you a reflective letter each evening (Web/PWA, iOS).
+- [Ori](https://github.com/jamyc3/ori-cognitive-health) - Cognitive-health journal that fuses your writing with biometric and wellbeing (WHO-5) data and writes you a reflective letter each evening (Web/PWA, iOS).
 
 ### Mood
 - [MoodCast](https://2appstudio.com/moodcast/) - Keep track of your daily mood & activities (Android).

--- a/README.MD
+++ b/README.MD
@@ -143,6 +143,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Podcast Tracker](http://www.podcasttracker.com/) -  Lets you log, aggregate and export your podcast listening history (Web).
 
 ### Mind & Cognition
+- [Ori](https://talk-to-me.ideaflow.page/) - Cognitive-health journal that fuses your writing with biometric and wellbeing (WHO-5) data and writes you a reflective letter each evening (Web/PWA, iOS).
 
 ### Mood
 - [MoodCast](https://2appstudio.com/moodcast/) - Keep track of your daily mood & activities (Android).


### PR DESCRIPTION
Adds Ori to the Applications and Platforms > Mind & Cognition section.

Ori is a cognitive-health journal: you write or speak about your day, and it fuses that with biometric data (Oura / Apple Health), calendar signals, and a daily WHO-5 wellbeing check-in, then writes you a reflective letter each evening. Web/PWA and iOS. Open source (MIT).

Live: https://talk-to-me.ideaflow.page/
Repo: https://github.com/jamyc3/ori-cognitive-health