### PR TITLE
Add Verified Supplement Evidence dataset to Research and Analysis

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -231,6 +231,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Human API](http://humanapi.co/) - Health data integration platform.
 - [FoundMyFitness](https://www.foundmyfitness.com/genetics) - Comprehensive genetic report from on self-uploaded genetic data.
 - [DNA Claude Analysis](https://github.com/shmlkv/dna-claude-analysis) - Interactive personal genome analysis toolkit using Claude Code. Analyzes raw DNA data from 23andMe, AncestryDNA, and others across 17 categories including health risks, pharmacogenomics, nutrition, and longevity.
+- [Verified Supplement Evidence](https://github.com/erinheit451/verified-supplement-evidence) - Open, evidence-graded dataset for supplement self-experimenters covering dosing, bioavailability by form, drug-nutrient interactions, NHANES deficiency prevalence, FDA FAERS adverse-event signals, and cost-per-effective-dose, with every clinical claim citing a PubMed PMID (CC BY 4.0).
 
 ## Open Source Projects
 


### PR DESCRIPTION
Adds **Verified Supplement Evidence** under **Research and Analysis**.

- **Repo:** https://github.com/erinheit451/verified-supplement-evidence
- **License:** CC BY 4.0 (DOI 10.57967/hf/9356)

An open, evidence-graded dataset useful for supplement self-experimenters: dosing, bioavailability by form, drug-nutrient interactions, NHANES deficiency prevalence, FDA FAERS adverse-event signals, and cost-per-effective-dose. Every clinical claim cites a PubMed PMID.

Placed in Research and Analysis (rather than the app-only Diet section) since it is a reference dataset, sitting with the other analysis/reference resources. Followed the existing bullet format; confirmed it is not already listed.
