### PR TITLE
Add SoulSync to Mood section

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -164,6 +164,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [MirrorNotes](https://mirrornotes.org) - Private AI journaling with on-device mood tracking, daily reflection prompts, and "Ask your journal" queries. AI (Gemma 3) runs locally, so no data leaves your device (iOS).
 - [Moods by Mokriya](https://itunes.apple.com/us/app/moods-tracking-for-better-mental-health/id1023271188?mt=8) - Quick track your mood as good, okay or bad. Specify feelings using a word cloud. No data export option. (iOS, Apple Watch).
 - [DailyVox](https://getdailyvox.com) - Voice journal that tracks mood and surfaces patterns on-device, building a private "Digital Twin" from your spoken entries. No account or cloud; free and open source (iOS).
+- [SoulSync](https://github.com/Antimatter543/mood-tracker) - Free, open source mood tracker that stores everything on-device with no account, no cloud sync, and no ads required (Android).
 
 ### Sleep
 - [Sleep as Android](http://sleep.urbandroid.org/) - Full featured sleep tracker with wearable integration (Android).


### PR DESCRIPTION
Adds SoulSync, a free, open-source mood tracker for Android, to the Mood subsection under Applications and Platforms.

- Stores everything on-device (SQLite), no account or cloud sync required, no ads, no subscription.
- GPL-3.0, Android.
- Added to the bottom of the category per the contributing guide.

Disclosure: we maintain this app (built by our founder).