### PR TITLE
Add Kaiord to Fitness applications

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -62,6 +62,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Gym Hero](https://gymhero.me/) - Track workouts, strength training and other fitness exercise (iOS, Web)
 - [OpenTracks](https://opentracksapp.com/) - Privacy-respecting offline-capable fitness activity tracker (Android).
 - [Smart Runner](https://runnerapp.pro/) - Privacy-respecting on-device running and marathon training coach with adaptive plans (iOS & Apple Watch).
+- [Kaiord](https://kaiord.com/) - Open-source, local-first training platform: weekly calendar, workout editor, AI assistant, Garmin & WHOOP sync, and health analytics; converts FIT, TCX, and ZWO workout files in the browser (Web).
 
 ### Places & Travel
 - [RoadGoat](https://www.roadgoat.com/) - Travel tracking, automated integrations with many platforms listed here (Web).


### PR DESCRIPTION
Adds [Kaiord](https://kaiord.com) ([GitHub](https://github.com/pablo-albaladejo/kaiord)) to **Applications and Platforms → Fitness**.

Kaiord is an open-source (MIT), local-first training platform: weekly training calendar, visual workout editor, AI assistant, Garmin & WHOOP sync, and health/lab analytics. All data stays in the browser (IndexedDB, no account needed), and it converts FIT, TCX, ZWO, and Garmin Connect workout files entirely client-side — a good fit for QS users who want to own their training data.

PR opened by Claude Code on behalf of the project author, @pablo-albaladejo.