### PR TITLE
Add o2ring-analyzer to Sleep section

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -171,6 +171,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Pillow](https://neybox.com/pillow/) - Track your sleep from your Apple Watch or iPhone (iOS). 
 - [CPAP Clarity](https://cpapclarity.com) - Analyzes CPAP and sleep data in your browser and explains it in plain language, with no upload and no account (Web).
 - [AirwayLab](https://github.com/airwaylab-app/airwaylab) - Browser-based PAP therapy analysis with flow limitation scoring and an oximetry pipeline. All processing runs locally (Web).
+- [o2ring-analyzer](https://github.com/nighttimecf/o2ring-analyzer) - Command-line analyzer for overnight pulse-oximetry recordings: SpO2 statistics, ODI at 3% and 4% thresholds, desaturation events, nadir, with CSV/JSON/Excel export.
 
 ### Tally
 


### PR DESCRIPTION
Adds o2ring-analyzer to the Sleep section.

Overnight pulse oximetry has become a common self-tracking method, but the vendor software for these devices exports raw per-second readings with no aggregate analysis. This tool fills that gap: it computes the oxygen desaturation index under both the 3% and 4% threshold definitions, enumerates individual desaturation events with their durations, reports nadir SpO2 and time below threshold, and exports results as CSV, JSON or Excel.

Currently supports the Wellue O2Ring; the parser is structured so other oximeter exports can be added.

- MIT licensed
- PyPI: https://pypi.org/project/o2ring-analyzer/
- Archived with DOI: https://doi.org/10.5281/zenodo.21439509
- Test suite and CI included

I followed the entry format used elsewhere in this section. Happy to move it to Open Source Projects instead if that placement makes more sense.