### PR TITLE
Add Chompass

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -104,7 +104,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [MyFitnessPal](http://www.myfitnesspal.com/) - Food tracking and diet plan app (iOS & Android).
 - [Fat Secret](https://www.fatsecret.com/) - Calorie counter and diet tracker for weight loss (iOS & Android).
 - [Cronometer](https://cronometer.com/) - Food, activity, and biometric tracker (iOS & Android).
-- [Chompass](https://chompass.app/) - FOSS Calorie and food diary with local storage, optional BYOK AI, Barcode/OFF input (Android & browser PWA). Android app available on [F-Droid](https://f-droid.org/packages/app.chompass).
+- [Chompass](https://chompass.app/) - FOSS Calorie and food diary with local storage, optional BYOK AI, Barcode/OFF input (Android & browser PWA; [F-Droid](https://f-droid.org/packages/app.chompass)).
 - [Zero](https://www.zerofasting.com/) - A simple fasting tracker used for intermittent, circadian rhythm, and custom fasting (iOS & Android). 
 - [Bitesnap](https://www.getbitesnap.com/) - Image based food logging app powered by computer vision (iOS & Android).
 - [Coffee It](https://apps.apple.com/us/app/coffee-it-record-caffeine/id1216049514) - Record Caffeine intake, with database inside & Apple Health sync. (iOS)

--- a/README.MD
+++ b/README.MD
@@ -104,6 +104,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [MyFitnessPal](http://www.myfitnesspal.com/) - Food tracking and diet plan app (iOS & Android).
 - [Fat Secret](https://www.fatsecret.com/) - Calorie counter and diet tracker for weight loss (iOS & Android).
 - [Cronometer](https://cronometer.com/) - Food, activity, and biometric tracker (iOS & Android).
+- [Chompass](https://chompass.app/) - FOSS Calorie and food diary with local storage, optional BYOK AI, Barcode/OFF input (Android & browser PWA).
 - [Zero](https://www.zerofasting.com/) - A simple fasting tracker used for intermittent, circadian rhythm, and custom fasting (iOS & Android). 
 - [Bitesnap](https://www.getbitesnap.com/) - Image based food logging app powered by computer vision (iOS & Android).
 - [Coffee It](https://apps.apple.com/us/app/coffee-it-record-caffeine/id1216049514) - Record Caffeine intake, with database inside & Apple Health sync. (iOS)

--- a/README.MD
+++ b/README.MD
@@ -104,7 +104,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [MyFitnessPal](http://www.myfitnesspal.com/) - Food tracking and diet plan app (iOS & Android).
 - [Fat Secret](https://www.fatsecret.com/) - Calorie counter and diet tracker for weight loss (iOS & Android).
 - [Cronometer](https://cronometer.com/) - Food, activity, and biometric tracker (iOS & Android).
-- [Chompass](https://chompass.app/) - FOSS Calorie and food diary with local storage, optional BYOK AI, Barcode/OFF input (Android & browser PWA).
+- [Chompass](https://chompass.app/) - FOSS Calorie and food diary with local storage, optional BYOK AI, Barcode/OFF input (Android & browser PWA). Android app available on [F-Droid](https://f-droid.org/packages/app.chompass).
 - [Zero](https://www.zerofasting.com/) - A simple fasting tracker used for intermittent, circadian rhythm, and custom fasting (iOS & Android). 
 - [Bitesnap](https://www.getbitesnap.com/) - Image based food logging app powered by computer vision (iOS & Android).
 - [Coffee It](https://apps.apple.com/us/app/coffee-it-record-caffeine/id1216049514) - Record Caffeine intake, with database inside & Apple Health sync. (iOS)


### PR DESCRIPTION
also added issue: #161 

this adds Chompass, which is an ad-free calorie and food diary for Android with a companion browser PWA. Local-first data policy: no account, no ads, no analytics. Optional AI is BYOK (user-supplied API key) or optional on-device Gemma on Android, neither required for logging. Open JSON exports for diary and body metrics.

licence: MIT
Source: https://codeberg.org/fitguy/Chompass
website: https://chompass.app
PWA: https://chompass.app/app