### PR TITLE
Add Wellness Project to Aggregators & Dashboards

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -85,7 +85,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [HealthSync](https://healthsync.megabyte.sh/apple-health-app-sync) - Sync selected Apple Health data to a private backend API (iOS).
 - [Bloodboy](https://github.com/ashugaev/bloodboy-biomarkers-tracker) - Biomarker analyzer that extracts lab results from PDFs, converts units, and visualizes trends.
 - [LogZero](https://logzero.app) - Private tracker for mood, food, weight, meds, and exercise with a local correlation engine that surfaces relationships between metrics; on-device, no account (iOS).
-- [Wellness Project](https://wellnessproject.ai) - Fitness, nutrition, and longevity dashboard that aggregates Apple Health, Health Connect, Fitbit, and Oura, with AI coaching drawn from your full history (Web, iOS & Android).
+- [Wellness Project](https://wellnessproject.ai) - Dashboard that aggregates Apple Health, Health Connect, Fitbit, and Oura, with manual logging for food, workouts, and lab results (web, iOS & Android).
 
 ### Automation
 - [Tasker](https://play.google.com/store/apps/details?id=net.dinglisch.android.taskerm&hl=en) - Automation and event triggering app (Android).

--- a/README.MD
+++ b/README.MD
@@ -85,6 +85,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [HealthSync](https://healthsync.megabyte.sh/apple-health-app-sync) - Sync selected Apple Health data to a private backend API (iOS).
 - [Bloodboy](https://github.com/ashugaev/bloodboy-biomarkers-tracker) - Biomarker analyzer that extracts lab results from PDFs, converts units, and visualizes trends.
 - [LogZero](https://logzero.app) - Private tracker for mood, food, weight, meds, and exercise with a local correlation engine that surfaces relationships between metrics; on-device, no account (iOS).
+- [Wellness Project](https://wellnessproject.ai) - Fitness, nutrition, and longevity dashboard that aggregates Apple Health, Health Connect, Fitbit, and Oura, with AI coaching drawn from your full history (Web, iOS & Android).
 
 ### Automation
 - [Tasker](https://play.google.com/store/apps/details?id=net.dinglisch.android.taskerm&hl=en) - Automation and event triggering app (Android).


### PR DESCRIPTION
@
Adding [Wellness Project](https://wellnessproject.ai) to Aggregators & Dashboards.

Why it fits: it pulls a person's tracking data into one place rather than generating a single stream. It syncs Apple Health / HealthKit, Health Connect, Fitbit, Oura, and Google Health, alongside food, workout, body-composition, and lab logging, then reads across the whole history to answer questions and surface trends. Available on web, iOS, and Android.

Checked against the contributing guidelines: single suggestion, added to the bottom of the relevant category, `[resource](link) - Description.` format, no mention of the movement name in the description, no trailing whitespace.
@